### PR TITLE
Add ENS support

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -9,7 +9,7 @@
     </a>
     <button (click)="connectWallet()">
       <div *ngIf="wallet.connected">
-        {{wallet.userAddress.substring(0, 14)}}
+        {{accountName}}
       </div>
       <div *ngIf="!wallet.connected">
         Connect Wallet

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { WalletService } from '../wallet.service';
 import { ethers } from 'ethers';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-header',
@@ -10,10 +11,20 @@ import { ethers } from 'ethers';
 export class HeaderComponent implements OnInit {
   accountName: string;
 
-  constructor(public wallet: WalletService) { }
+  private _serviceSubscription: Subscription;
+
+  constructor(public wallet: WalletService) {
+    this._serviceSubscription = this.wallet.connectedEvent.subscribe({
+      next: (address: string) => this.setAccountName(address)
+    })
+  }
 
   ngOnInit(): void {
     this.accountName = "unknown";
+  }
+
+  ngOnDestroy(): void {
+    this._serviceSubscription.unsubscribe();
   }
 
   connectWallet() {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { WalletService } from '../wallet.service';
+import { ethers } from 'ethers';
 
 @Component({
   selector: 'app-header',
@@ -7,13 +8,27 @@ import { WalletService } from '../wallet.service';
   styleUrls: ['./header.component.css']
 })
 export class HeaderComponent implements OnInit {
+  accountName: string;
 
   constructor(public wallet: WalletService) { }
 
   ngOnInit(): void {
+    this.accountName = "unknown";
   }
 
   connectWallet() {
     this.wallet.connect(() => { }, () => { }, false);
+  }
+
+  setAccountName(address: string): void {
+    this.accountName = `${address.substring(0, 6)}...${address.slice(-4)}`
+
+    const ethersProvider = new ethers.providers.Web3Provider(this.wallet.web3.givenProvider);
+    ethersProvider.lookupAddress(address)
+      .then(lookedupAddress => {
+        if (lookedupAddress) {
+          this.accountName = lookedupAddress;
+        }
+      })
   }
 }

--- a/src/app/wallet.service.ts
+++ b/src/app/wallet.service.ts
@@ -8,12 +8,12 @@ import { isNullOrUndefined } from 'util';
   providedIn: 'root'
 })
 export class WalletService extends Web3Enabled {
-  connectedEvent: EventEmitter<null>;
+  connectedEvent: EventEmitter<string>;
   disconnectedEvent: EventEmitter<null>;
 
   constructor(@Inject(WEB3) public web3: Web3) {
     super(web3);
-    this.connectedEvent = new EventEmitter<null>();
+    this.connectedEvent = new EventEmitter<string>();
     this.disconnectedEvent = new EventEmitter<null>();
   }
 
@@ -27,7 +27,7 @@ export class WalletService extends Web3Enabled {
 
   async connect(onConnected, onError, isStartupMode: boolean) {
     const _onConnected = () => {
-      this.connectedEvent.emit();
+      this.connectedEvent.emit(this.state.address);
       onConnected();
     };
     const _onError = () => {


### PR DESCRIPTION
This PR adds support for ENS names in the header, for connected accounts that have a reverse record set.

It also "cleans up" the display of ethereum addresses that do not have an ENS name, by displaying the first 4 and last 4 characters of the address.

![Screen Shot 2022-01-17 at 4 15 16 PM](https://user-images.githubusercontent.com/706929/149837765-553cb0e3-f3a9-4e0e-8fe5-1fd4fe5bea12.png)
